### PR TITLE
License metric

### DIFF
--- a/src/url_list/evalUrls.ts
+++ b/src/url_list/evalUrls.ts
@@ -1,19 +1,23 @@
 import * as fs from "fs";
 import * as path from "path";
 import { RateLimiter } from "../utils/apiRateLimit";
+import * as LicenseRunner from "./licenseMetric/licenseRunner";
 
 async function eval_file(filepath: string = "URL_FILE_PATH"): Promise<void> {
   const url_list = get_urls(filepath);
-  url_list.forEach((urlstr) => {
+  url_list.forEach(async (urlstr) => {
+    const limiter = new RateLimiter();
+    const url = CreateApiUrl(urlstr);
+    const licenseScore = await LicenseRunner.getLicenseScore(limiter, url);
+    console.log(urlstr, licenseScore);
     //do something
   });
-  const limiter = new RateLimiter();
-  const info = await limiter.getGitHubInfo("/repos/ShaoNingHuang/461_CLI");
-  console.log("info: " + info.ssh_url);
-  const info2 = await limiter.getGitHubInfo("/repos/ShaoNingHuang/461_CLI");
-  console.log("info2: " + info2.ssh_url);
-  console.log("Exiting...");
-  process.exit(0);
+}
+
+function CreateApiUrl(url: string): string {
+  const username = url.split("/")[3];
+  const repo = url.split("/")[4];
+  return `/repos/${username}/${repo}`;
 }
 
 function get_urls(filepath: string): string[] {

--- a/src/url_list/licenseMetric/licenseRunner.ts
+++ b/src/url_list/licenseMetric/licenseRunner.ts
@@ -1,0 +1,7 @@
+async function getLicenseScore(RateLimiter: any, url: string): Promise<number> {
+    const License = "LGPL-2.1";
+    const _license = await RateLimiter.getGitHubInfo(url + "/license");
+    return _license.license.spdx_id == License ? 1 : 0;
+}
+
+export { getLicenseScore };


### PR DESCRIPTION
Closes #40 

Return 0 if not using License LGPL-2.1 else return 1
The example use our repo and repo for express pakcage

![Screen Shot 2023-09-13 at 4 26 57 PM](https://github.com/TenGui/461_CLI/assets/87532510/b3af9131-a1c3-4ca3-8781-4502e04d0a5b)




Also added a helper function CreateApiUrl in the evalUrl.ts helping generate url to be feed to different runner 